### PR TITLE
set fixed mongoDB image version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: 'mongo:latest'
+    image: 'mongo:7.0.5-rc0-jammy'
     ports:
       - '27017:27017'
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: 'mongo:7.0.5-rc0-jammy'
+    image: 'mongo:7.0.4-jammy'
     ports:
       - '27017:27017'
     volumes:


### PR DESCRIPTION
fixes issue #10 
its a lightweight image tag - available for ARM64 and AMD64 on linux.