### PR TITLE
clean must delete custom used "dist" folder

### DIFF
--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -47,3 +47,7 @@ artifacts {
         builtBy("packageFrontend")
     }
 }
+
+tasks.withType<Delete>().named("clean") {
+    delete("dist")
+}


### PR DESCRIPTION
otherwise old stuff can get assembled and breaks the jar. It happened.